### PR TITLE
Fix Spelling Errors - ControlKeys.cs

### DIFF
--- a/src/samples/Lithnet.CredentialProvider.Sample.net472.x64/ControlKeys.cs
+++ b/src/samples/Lithnet.CredentialProvider.Sample.net472.x64/ControlKeys.cs
@@ -13,7 +13,7 @@
         internal const string Checkbox = "Checkbox";
         internal const string LabelCheckboxValue = "LabelCheckbox";
         internal const string CommandLinkCheckboxValue = "CommandLinkCheckbox";
-        internal const string ImageUserTile = "UerTileImage";
+        internal const string ImageUserTile = "UserTileImage";
         internal const string Combobox = "Combobox";
         internal const string LabelComboboxSelectedItem = "ComboSelectedItemLabel";
         internal const string CommandLinkComboboxAdd = "CommandLinkComboboxAdd";


### PR DESCRIPTION
lithnet/windows-credential-provider/tree/main/src/samples/Lithnet.CredentialProvider.Sample.net472.x64/ControlKeys.cs
Fix spelling error.