### PR TITLE
Make NotifyHostOfTileCollectionChange public

### DIFF
--- a/src/Lithnet.CredentialProvider/CredentialProviderBase.cs
+++ b/src/Lithnet.CredentialProvider/CredentialProviderBase.cs
@@ -270,7 +270,7 @@ namespace Lithnet.CredentialProvider
             this.Tiles = this.tiles.AsReadOnly();
         }
 
-        private void NotifyHostOfTileCollectionChange()
+        public void NotifyHostOfTileCollectionChange()
         {
             if (this.notifyOnTileCollectionChange)
             {


### PR DESCRIPTION
This make NotifyHostOfTileCollectionChange public instead of private.

This to be able to trigger credentials refresh without changing the tile collection, mainly to support a delayed auto-logon scenario without user interaction (#7). Correct logic on CredentialTile implementation (caching credentials, enabling/disabling autologon boolean, ...) would still be required.

On a side note, as this library is being adopted more widely, it would be good to start tags/releases later on for proper changelog / changes tracking during upgrade.

About myself as it is my first contribution on this project: I have 15 years experience with Credential Provider development (ok, it was msgina before... 😝), mainly in C++ but I'm making a new one in .NET now and will use this project as a base. I strongly believe this kind of project is required and need to be properly maintained.