### PR TITLE
Add ReloadUserTiles method and update IsAutoLogon property

### DIFF
--- a/src/Lithnet.CredentialProvider/CredentialProviderBase.ICredentialProvider.cs
+++ b/src/Lithnet.CredentialProvider/CredentialProviderBase.ICredentialProvider.cs
@@ -169,23 +169,20 @@ namespace Lithnet.CredentialProvider
 
                 this.notifyOnTileCollectionChange = true;
 
-                var autoLogonTile = this.Tiles.FirstOrDefault(t => t.IsAutoLogon);
-                var defaultTile = this.Tiles.FirstOrDefault(t => t.IsDefault);
+                var defaultTile = this.DefaultTile;
 
-                uint defaultIndex = CREDENTIAL_PROVIDER_NO_DEFAULT;
-                if (autoLogonTile != null)
+                if (defaultTile != null)
                 {
-                    defaultIndex = (uint)this.tiles.IndexOf(autoLogonTile);
-                }
-                else if (defaultTile != null)
-                {
-                    defaultIndex = (uint)this.tiles.IndexOf(defaultTile);
+                    var index = this.tiles.IndexOf(defaultTile);
+
+                    if (index >= 0)
+                    {
+                        pdwDefault = (uint)index;
+                        pbAutoLogonWithDefault = this.DefaultTileAutoLogon ? 1 : 0;
+                    }
                 }
 
                 pdwCount = (uint)this.Tiles.Count;
-                pdwDefault = defaultIndex;
-                pbAutoLogonWithDefault = autoLogonTile == null ? 0 : 1;
-
                 this.logger.LogTrace($"GetCredentialCount returning pdwCount: {pdwCount}, pdwDefault: {pdwDefault}, pbAutoLogonWithDefault: {pbAutoLogonWithDefault}");
 
                 return HRESULT.S_OK;

--- a/src/Lithnet.CredentialProvider/CredentialProviderBase.cs
+++ b/src/Lithnet.CredentialProvider/CredentialProviderBase.cs
@@ -114,6 +114,14 @@ namespace Lithnet.CredentialProvider
         /// Gets a value that indicates if the credential provider should show a generic tile. That is, a tile that is not associated with a specific user.
         /// </summary>
         public abstract bool ShouldIncludeGenericTile();
+        
+        /// <summary>
+        /// Notifies LogonUI that one of more of the tile items has been modified, and should be reloaded
+        /// </summary>
+        public void ReloadUserTiles()
+        {
+            this.NotifyHostOfTileCollectionChange();
+        }
 
         /// <summary>
         /// Adds additional user tiles to the collection, and notifies LogonUI that new tiles are available

--- a/src/Lithnet.CredentialProvider/CredentialProviderBase.cs
+++ b/src/Lithnet.CredentialProvider/CredentialProviderBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Lithnet.CredentialProvider.Interop;
@@ -114,7 +115,28 @@ namespace Lithnet.CredentialProvider
         /// Gets a value that indicates if the credential provider should show a generic tile. That is, a tile that is not associated with a specific user.
         /// </summary>
         public abstract bool ShouldIncludeGenericTile();
-        
+
+        protected internal CredentialTile DefaultTile { get; set; }
+
+        protected internal bool DefaultTileAutoLogon { get; set; }
+
+        public void SetDefaultTile(CredentialTile tile, bool autoLogon)
+        {
+            if (this.DefaultTile == tile && this.DefaultTileAutoLogon == autoLogon)
+            {
+                return;
+            }
+
+            if (!this.Tiles.Contains(tile))
+            {
+                throw new InvalidOperationException("The default tile must be one of the tiles provided by the credential provider");
+            }
+
+            this.DefaultTile = tile;
+            this.DefaultTileAutoLogon = autoLogon;
+            this.ReloadUserTiles();
+        }
+
         /// <summary>
         /// Notifies LogonUI that one of more of the tile items has been modified, and should be reloaded
         /// </summary>

--- a/src/Lithnet.CredentialProvider/CredentialTile.ICredentialProviderCredential.cs
+++ b/src/Lithnet.CredentialProvider/CredentialTile.ICredentialProviderCredential.cs
@@ -67,7 +67,7 @@ namespace Lithnet.CredentialProvider
                 this.logger.LogTrace("SetSelected");
                 this.IsSelected = true;
                 this.OnSelected();
-                pbAutoLogon = this.ShouldAutoLogon() ? 1 : 0;
+                pbAutoLogon = this.OnSelectedShouldAutoLogon() ? 1 : 0;
                 return HRESULT.S_OK;
             }
             catch (Exception ex)

--- a/src/Lithnet.CredentialProvider/CredentialTile.ICredentialProviderCredential.cs
+++ b/src/Lithnet.CredentialProvider/CredentialTile.ICredentialProviderCredential.cs
@@ -66,8 +66,8 @@ namespace Lithnet.CredentialProvider
             {
                 this.logger.LogTrace("SetSelected");
                 this.IsSelected = true;
-                this.OnSelected(out bool autoLogon);
-                pbAutoLogon = autoLogon ? 1 : 0;
+                this.OnSelected();
+                pbAutoLogon = this.ShouldAutoLogon() ? 1 : 0;
                 return HRESULT.S_OK;
             }
             catch (Exception ex)

--- a/src/Lithnet.CredentialProvider/CredentialTile.ICredentialProviderCredential.cs
+++ b/src/Lithnet.CredentialProvider/CredentialTile.ICredentialProviderCredential.cs
@@ -66,8 +66,8 @@ namespace Lithnet.CredentialProvider
             {
                 this.logger.LogTrace("SetSelected");
                 this.IsSelected = true;
-                pbAutoLogon = this.IsAutoLogon ? 1 : 0;
-                this.OnSelected();
+                this.OnSelected(out bool autoLogon);
+                pbAutoLogon = autoLogon ? 1 : 0;
                 return HRESULT.S_OK;
             }
             catch (Exception ex)

--- a/src/Lithnet.CredentialProvider/CredentialTile.cs
+++ b/src/Lithnet.CredentialProvider/CredentialTile.cs
@@ -164,7 +164,14 @@ namespace Lithnet.CredentialProvider
         /// <summary>
         /// Called when the user selects this tile
         /// </summary>
-        protected virtual void OnSelected() { }
+        /// <param name="autoLogon">A value that indicates if logon should be performed immediately, without waiting for further user input</param>
+        /// <remarks>
+        /// In Windows 10, if a credential provider wants to automatically log the user on in a situation Windows does not think is appropriate, the system will display a sign in button as a speed bump. One example of this is when a user with an empty password locks the computer or signs out. In that scenario, Windows does not directly log the user back in.
+        /// </remarks>
+        protected virtual void OnSelected(out bool autoLogon)
+        {
+            autoLogon = false;
+        }
 
         /// <summary>
         /// Called when a user deselects this tile

--- a/src/Lithnet.CredentialProvider/CredentialTile.cs
+++ b/src/Lithnet.CredentialProvider/CredentialTile.cs
@@ -170,7 +170,7 @@ namespace Lithnet.CredentialProvider
         /// <remarks>
         /// In Windows 10, if a credential provider wants to automatically log the user on in a situation Windows does not think is appropriate, the system will display a sign in button as a speed bump. One example of this is when a user with an empty password locks the computer or signs out. In that scenario, Windows does not directly log the user back in.
         /// </remarks>
-        protected virtual bool ShouldAutoLogon() => false;
+        protected virtual bool OnSelectedShouldAutoLogon() => false;
 
         /// <summary>
         /// Called when a user deselects this tile

--- a/src/Lithnet.CredentialProvider/CredentialTile.cs
+++ b/src/Lithnet.CredentialProvider/CredentialTile.cs
@@ -15,6 +15,7 @@ namespace Lithnet.CredentialProvider
         private protected ICredentialProviderCredentialEvents2 events2;
 
         private protected ControlCollection controls;
+        private bool isAutoLogon;
 
         protected CredentialTile(CredentialProviderBase credentialProvider)
         {
@@ -37,7 +38,16 @@ namespace Lithnet.CredentialProvider
         /// <summary>
         /// Gets a value that indicates if the user should be automatically logged on when the tile is selected. The tile must also have IsDefault set to true.
         /// </summary>
-        public bool IsAutoLogon { get; set; }
+        public bool IsAutoLogon
+        {
+            get => this.isAutoLogon;
+            set
+            {
+                this.isAutoLogon = value;
+                this.CredentialProvider.ReloadUserTiles();
+
+            }
+        }
 
         /// <summary>
         /// Gets a value indicating if this should be the default time
@@ -87,7 +97,7 @@ namespace Lithnet.CredentialProvider
         /// Gets the HWND of the parent of the credential provider, and notifies LogonUI or CredUI that we need to create a Window
         /// </summary>
         /// <returns>A HWND to the parentobject</returns>
-        /// <exception cref="InvalidOperationException">The method was called before the host has advised that is ready to rpovide events</exception>
+        /// <exception cref="InvalidOperationException">The method was called before the host has advised that is ready to provide events</exception>
         /// <exception cref="COMException">The request to obtain the parent window HWND failed</exception>
         public IntPtr CreateParentWindowHwnd()
         {

--- a/src/Lithnet.CredentialProvider/CredentialTile.cs
+++ b/src/Lithnet.CredentialProvider/CredentialTile.cs
@@ -40,19 +40,16 @@ namespace Lithnet.CredentialProvider
         /// </summary>
         public bool IsAutoLogon
         {
-            get => this.isAutoLogon;
-            set
-            {
-                this.isAutoLogon = value;
-                this.CredentialProvider.ReloadUserTiles();
-
-            }
+            get => this.CredentialProvider.DefaultTile == this && this.CredentialProvider.DefaultTileAutoLogon;
         }
 
         /// <summary>
-        /// Gets a value indicating if this should be the default time
+        /// Gets a value indicating if this should be the default tile
         /// </summary>
-        public bool IsDefault { get; set; }
+        public bool IsDefault
+        {
+            get => this.CredentialProvider.DefaultTile == this;
+        }
 
         /// <summary>
         /// Gets the current usage scenario
@@ -164,14 +161,16 @@ namespace Lithnet.CredentialProvider
         /// <summary>
         /// Called when the user selects this tile
         /// </summary>
-        /// <param name="autoLogon">A value that indicates if logon should be performed immediately, without waiting for further user input</param>
+        protected virtual void OnSelected() { }
+
+        /// <summary>
+        /// Called after a tiles is selected to determine if the user should be automatically logged on
+        /// </summary>
+        /// <returns>True, if a logon should be immediately attempted</returns>
         /// <remarks>
         /// In Windows 10, if a credential provider wants to automatically log the user on in a situation Windows does not think is appropriate, the system will display a sign in button as a speed bump. One example of this is when a user with an empty password locks the computer or signs out. In that scenario, Windows does not directly log the user back in.
         /// </remarks>
-        protected virtual void OnSelected(out bool autoLogon)
-        {
-            autoLogon = false;
-        }
+        protected virtual bool ShouldAutoLogon() => false;
 
         /// <summary>
         /// Called when a user deselects this tile

--- a/src/Lithnet.CredentialProvider/CredentialTile.cs
+++ b/src/Lithnet.CredentialProvider/CredentialTile.cs
@@ -38,7 +38,7 @@ namespace Lithnet.CredentialProvider
         /// <summary>
         /// Gets a value that indicates if the user should be automatically logged on when the tile is selected. The tile must also have IsDefault set to true.
         /// </summary>
-        public bool IsAutoLogon
+        public bool IsDefaultTileAutoLogon
         {
             get => this.CredentialProvider.DefaultTile == this && this.CredentialProvider.DefaultTileAutoLogon;
         }
@@ -46,7 +46,7 @@ namespace Lithnet.CredentialProvider
         /// <summary>
         /// Gets a value indicating if this should be the default tile
         /// </summary>
-        public bool IsDefault
+        public bool IsDefaultTile
         {
             get => this.CredentialProvider.DefaultTile == this;
         }

--- a/src/Lithnet.CredentialProvider/CredentialTile.cs
+++ b/src/Lithnet.CredentialProvider/CredentialTile.cs
@@ -13,9 +13,7 @@ namespace Lithnet.CredentialProvider
         private protected readonly ICredentialProviderLogger logger;
         private protected ICredentialProviderCredentialEvents events;
         private protected ICredentialProviderCredentialEvents2 events2;
-
         private protected ControlCollection controls;
-        private bool isAutoLogon;
 
         protected CredentialTile(CredentialProviderBase credentialProvider)
         {


### PR DESCRIPTION
- Added ReloadUserTiles method to CredentialProviderBase to notify LogonUI of tile modifications.
- Introduced private field isAutoLogon in CredentialTile.
- Updated IsAutoLogon property in CredentialTile to use a backing field and call ReloadUserTiles on set.
- Corrected typo in XML documentation for CreateParentWindowHwnd method.