### PR TITLE
Update CredentialTile3 class visibility and enhance BitmapControl functionality

### DIFF
--- a/src/Lithnet.CredentialProvider/Controls/BitmapControl.cs
+++ b/src/Lithnet.CredentialProvider/Controls/BitmapControl.cs
@@ -25,6 +25,11 @@ namespace Lithnet.CredentialProvider
         protected BitmapControl(BitmapControl source) : base(source) { }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the bitmap should be displayed with transparency enabled.
+        /// </summary>
+        public bool EnableTransparent { get; set; } = false;
+
+        /// <summary>
         /// Specifies the background color that should replace any transparent elements of the image. This defaults to #707070
         /// </summary>
         public Color BackgroundColor
@@ -84,11 +89,15 @@ namespace Lithnet.CredentialProvider
             }
 
             var image = Bitmap.FromHbitmap(hbitmap);
-
+            if (this.EnableTransparent)
+            {
+                image.MakeTransparent(this.BackgroundColor);
+            }
             IntPtr buffer = IntPtr.Zero;
             using (MemoryStream ms = new MemoryStream())
             {
-                image.Save(ms, ImageFormat.Bmp);
+                var format = this.EnableTransparent ? ImageFormat.Png : ImageFormat.Bmp;
+                image.Save(ms, format);
                 var bitmapBytes = ms.ToArray();
                 size = (uint)bitmapBytes.Length;
                 buffer = Marshal.AllocCoTaskMem(bitmapBytes.Length);

--- a/src/Lithnet.CredentialProvider/CredentialTile3.ICredentialProviderCredential3.cs
+++ b/src/Lithnet.CredentialProvider/CredentialTile3.ICredentialProviderCredential3.cs
@@ -3,7 +3,7 @@ using Lithnet.CredentialProvider.Interop;
 
 namespace Lithnet.CredentialProvider
 {
-    internal abstract partial class CredentialTile3 : ICredentialProviderCredential3
+    public abstract partial class CredentialTile3 : ICredentialProviderCredential3
     {
         int ICredentialProviderCredential3.GetBitmapBufferValue(uint dwFieldID, out uint pImageBufferSize, out IntPtr ppImageBuffer)
         {
@@ -19,6 +19,7 @@ namespace Lithnet.CredentialProvider
                 if (this.Controls.TryGetControl<BitmapControl>(dwFieldID, FieldType.TileImage, out var instance))
                 {
                     var hbitmap = instance.GetBitmapBuffer(out pImageBufferSize);
+                    ppImageBuffer = hbitmap;
                     return HRESULT.S_OK;
                 }
 

--- a/src/Lithnet.CredentialProvider/CredentialTile3.cs
+++ b/src/Lithnet.CredentialProvider/CredentialTile3.cs
@@ -7,7 +7,7 @@ namespace Lithnet.CredentialProvider
     /// Represents a user credential tile that implements the functionality of <see cref="CredentialTile"/> and <see cref="CredentialTile2"/>, but includes support for dynamically updating bitmap images.
     /// </summary>
     /// <remarks>This interface is public, but undocumented by Microsoft. It is recommended to use <see cref="CredentialTile2"/> tiles unless this specific functionality is needed</remarks>
-    internal abstract partial class CredentialTile3 : CredentialTile2
+    public abstract partial class CredentialTile3 : CredentialTile2
     {
         protected CredentialTile3(CredentialProviderBase credentialProvider) : this(credentialProvider, null) { }
 

--- a/src/Lithnet.CredentialProvider/Lithnet.CredentialProvider.csproj
+++ b/src/Lithnet.CredentialProvider/Lithnet.CredentialProvider.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net6.0-windows;net7.0-windows;net8.0-windows;net461</TargetFrameworks>
+		<TargetFrameworks>net10.0-windows;net7.0-windows;net8.0-windows;net461</TargetFrameworks>
 		<RegisterForComInterop>false</RegisterForComInterop>
 		<OutputType>Library</OutputType>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -17,8 +17,7 @@
 		<Company>Lithnet</Company>
 		<Copyright>Copyright 2023 Lithnet Pty Ltd</Copyright>
 		<ProductName>Lithnet Windows Credential Provider</ProductName>
-		<VersionPrefix>1.1.0</VersionPrefix>
-		<VersionSuffix>beta1</VersionSuffix>
+		<VersionPrefix>1.1.28</VersionPrefix>
 		<Authors>Lithnet</Authors>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 		<AutoIncrementPackageRevision>true</AutoIncrementPackageRevision>


### PR DESCRIPTION
- Changed the visibility of the `CredentialTile3` class from internal to public.
- Added a new property `EnableTransparent` to `BitmapControl` to allow transparency in bitmap display.
- Updated dependences and version number.